### PR TITLE
Quick synchronization

### DIFF
--- a/src/app/album/page-album.component.ts
+++ b/src/app/album/page-album.component.ts
@@ -87,7 +87,7 @@ import { HelperFacade } from '@app/helper/helper.facade';
                 [song]="song"
                 [queue]="getIds(disk.songs)"
                 [trackNumber]="song.tags.track.no"
-                [class.selected]="(currentSongPath$ | async) === song.entryPath"
+                [class.selected]="(currentSongPath$ | async) === song.id"
                 cdkMonitorSubtreeFocus
               ></app-track-list-item>
             </div>
@@ -134,7 +134,7 @@ export class PageAlbumComponent implements OnInit {
   currentSongPath$ = this.player.getCurrentSong$().pipe(
     filter((id): id is SongId => !!id),
     switchMap((path) => this.songs.getByKey(path)),
-    map((song) => song?.entryPath)
+    map((song) => song?.id)
   );
 
   cover$!: Observable<string | undefined>;
@@ -153,7 +153,7 @@ export class PageAlbumComponent implements OnInit {
   ) {}
 
   trackBy(index: number, song: Song): string {
-    return song.entryPath;
+    return song.id;
   }
 
   trackByDisk(index: number, disk: { key: number | null }): number {
@@ -248,6 +248,6 @@ export class PageAlbumComponent implements OnInit {
   }
 
   getIds(songs: Song[]): SongId[] {
-    return songs.map((s) => s.entryPath);
+    return songs.map((s) => s.id);
   }
 }

--- a/src/app/core/components/album.component.ts
+++ b/src/app/core/components/album.component.ts
@@ -90,7 +90,7 @@ export class AlbumComponent implements OnInit {
   ngOnInit(): void {
     this.queue$ = this.songs.getByAlbumKey(this.album.id).pipe(
       map((songs) => songs ?? []),
-      map((songs) => songs.map((s) => s.entryPath))
+      map((songs) => songs.map((s) => s.id))
     );
 
     this.cover$ = this.pictures.getAlbumCover(

--- a/src/app/core/components/list.component.ts
+++ b/src/app/core/components/list.component.ts
@@ -40,7 +40,7 @@ export class OptMatRippleDirective extends MatRipple implements OnInit {
   selector: 'app-list',
   template: `
     <div
-      *ngFor="let item of items"
+      *ngFor="let item of items; trackBy: trackBy"
       class="item"
       [appMatRipple]="!!item.routerLink"
       [class.cursor]="!!item.routerLink"
@@ -180,7 +180,11 @@ export class ListComponent {
     }
   }
 
-  play(queue: SongId[]) {
+  play(queue: SongId[]): void {
     this.helper.playQueue(queue, 0);
+  }
+
+  trackBy(index: number, item: ListItem): string {
+    return item.title;
   }
 }

--- a/src/app/core/components/playlist-likes.component.ts
+++ b/src/app/core/components/playlist-likes.component.ts
@@ -53,7 +53,7 @@ export class PlaylistLikesComponent implements OnInit {
       .getAll('likedOn')
       .pipe(map((songs) => [...songs].reverse()));
 
-    this.queue$ = songs$.pipe(map((songs) => songs.map((s) => s.entryPath)));
+    this.queue$ = songs$.pipe(map((songs) => songs.map((s) => s.id)));
 
     this.menuItems$ = songs$.pipe(
       map((songs) => [
@@ -62,7 +62,7 @@ export class PlaylistLikesComponent implements OnInit {
           icon: Icons.shuffle,
           click: () =>
             this.helper.playSongs(
-              songs.map((s) => s.entryPath),
+              songs.map((s) => s.id),
               true
             ),
         },
@@ -71,7 +71,7 @@ export class PlaylistLikesComponent implements OnInit {
           icon: Icons.playlistPlay,
           click: () =>
             this.helper.addSongsToQueue(
-              songs.map((s) => s.entryPath),
+              songs.map((s) => s.id),
               true,
               'Your likes will play next'
             ),
@@ -81,7 +81,7 @@ export class PlaylistLikesComponent implements OnInit {
           icon: Icons.playlistPlus,
           click: () =>
             this.helper.addSongsToQueue(
-              songs.map((s) => s.entryPath),
+              songs.map((s) => s.id),
               false,
               'Your likes have been added to queue'
             ),

--- a/src/app/core/components/song-list-item.component.ts
+++ b/src/app/core/components/song-list-item.component.ts
@@ -27,15 +27,12 @@ import { HelperFacade } from '@app/helper/helper.facade';
       <app-player-button
         size="small"
         [queue]="queue"
-        [index]="queue.indexOf(song.entryPath)"
+        [index]="queue.indexOf(song.id)"
         *ngIf="queue"
       ></app-player-button>
     </div>
     <span class="title">
-      <span
-        [title]="song.title"
-        (click)="play(queue, queue.indexOf(song.entryPath))"
-      >
+      <span [title]="song.title" (click)="play(queue, queue.indexOf(song.id))">
         {{ song.title }}
       </span>
     </span>
@@ -218,15 +215,15 @@ export class SongListItemComponent implements OnInit {
   }
 
   playNext(song: Song): void {
-    this.helper.addSongToQueue(song.entryPath, true);
+    this.helper.addSongToQueue(song.id, true);
   }
 
   addToQueue(song: Song): void {
-    this.helper.addSongToQueue(song.entryPath, false);
+    this.helper.addSongToQueue(song.id, false);
   }
 
   addSongToPlaylist(song: Song): void {
-    this.helper.addSongsToPlaylist([song.entryPath]);
+    this.helper.addSongsToPlaylist([song.id]);
   }
 
   play(queue: SongId[], index: number) {

--- a/src/app/core/components/song-list.component.ts
+++ b/src/app/core/components/song-list.component.ts
@@ -11,7 +11,7 @@ import { PlayerFacade } from '@app/player/store/player.facade';
       [song]="song"
       [queue]="getIds(songs)"
       cdkMonitorSubtreeFocus
-      [class.selected]="(currentSongPath$ | async) === song.entryPath"
+      [class.selected]="(currentSongPath$ | async) === song.id"
     ></app-song-list-item>
   `,
   styles: [
@@ -43,10 +43,10 @@ export class SongListComponent {
   constructor(private player: PlayerFacade) {}
 
   trackBy(index: number, song: Song): string {
-    return song.entryPath;
+    return song.id;
   }
 
   getIds(songs: Song[]): SongId[] {
-    return songs.map((s) => s.entryPath);
+    return songs.map((s) => s.id);
   }
 }

--- a/src/app/core/components/top-bar.component.ts
+++ b/src/app/core/components/top-bar.component.ts
@@ -6,6 +6,7 @@ import { DatabaseService } from '@app/database/database.service';
 import { Store } from '@ngrx/store';
 import { PlayerFacade } from '@app/player/store/player.facade';
 import { SettingsFacade } from '@app/database/settings/settings.facade';
+import { ScannerFacade } from '@app/scanner/store/scanner.facade';
 
 @Component({
   selector: 'app-top-bar',
@@ -133,7 +134,7 @@ export class TopBarComponent {
     {
       text: 'Synchronize library',
       icon: Icons.sync,
-      click: (): void => this.settings.synchronizeLibrary(),
+      click: (): void => this.scanner.quickSync(),
     },
     {
       text: 'Clear database',
@@ -167,7 +168,8 @@ export class TopBarComponent {
     private store: Store,
     private storage: DatabaseService,
     private player: PlayerFacade,
-    private settings: SettingsFacade
+    private settings: SettingsFacade,
+    private scanner: ScannerFacade
   ) {}
 
   // scan(): void {

--- a/src/app/core/components/track-list-item.component.ts
+++ b/src/app/core/components/track-list-item.component.ts
@@ -13,15 +13,12 @@ import { HelperFacade } from '@app/helper/helper.facade';
       <app-player-button
         class="player-button"
         size="small"
-        [index]="queue.indexOf(song.entryPath)"
+        [index]="queue.indexOf(song.id)"
         [queue]="queue"
       ></app-player-button>
     </span>
     <span class="title">
-      <span
-        [title]="song.title"
-        (click)="play(queue, queue.indexOf(song.entryPath))"
-      >
+      <span [title]="song.title" (click)="play(queue, queue.indexOf(song.id))">
         {{ song.title }}
       </span>
     </span>
@@ -159,15 +156,15 @@ export class TrackListItemComponent {
   }
 
   playNext(song: Song): void {
-    this.helper.addSongToQueue(song.entryPath, true);
+    this.helper.addSongToQueue(song.id, true);
   }
 
   addToQueue(song: Song): void {
-    this.helper.addSongToQueue(song.entryPath, false);
+    this.helper.addSongToQueue(song.id, false);
   }
 
   addSongToPlaylist(song: Song): void {
-    this.helper.addSongsToPlaylist([song.entryPath]);
+    this.helper.addSongsToPlaylist([song.id]);
   }
 
   play(queue: SongId[], index: number) {

--- a/src/app/core/utils/removeFromArray.util.ts
+++ b/src/app/core/utils/removeFromArray.util.ts
@@ -1,0 +1,7 @@
+export const removeFromArray = <T>(array: T[], element: T): T[] => {
+  const indexToRemove = array.indexOf(element);
+  return [
+    ...array.slice(0, indexToRemove),
+    ...array.slice(indexToRemove + 1, array.length),
+  ];
+};

--- a/src/app/database/albums/album.facade.ts
+++ b/src/app/database/albums/album.facade.ts
@@ -43,6 +43,8 @@ export class AlbumFacade {
               ? {
                   ...stored,
                   artists: [...stored.artists, ...album.artists].filter(uniq),
+                  entries: [...stored.entries, ...album.entries].filter(uniq),
+                  updatedOn: Math.max(stored.updatedOn, album.updatedOn),
                 }
               : album
           ),

--- a/src/app/database/albums/album.model.ts
+++ b/src/app/database/albums/album.model.ts
@@ -2,6 +2,7 @@ import { hash } from '@app/core/utils';
 import { Opaque } from 'type-fest';
 import { PictureId } from '@app/database/pictures/picture.model';
 import { ArtistId } from '@app/database/artists/artist.model';
+import { EntryId } from '@app/database/entries/entry.model';
 
 export type AlbumId = Opaque<string, Album>;
 
@@ -10,6 +11,7 @@ export const getAlbumId = (artist?: string, title?: string): AlbumId =>
 
 export type Album = {
   id: AlbumId;
+  entries: EntryId[];
   albumArtist: { name: string; id: ArtistId };
   artists: ArtistId[];
   likedOn?: number;

--- a/src/app/database/albums/album.reducer.ts
+++ b/src/app/database/albums/album.reducer.ts
@@ -41,7 +41,7 @@ export const albumReducer = createReducer(
   on(removeAllAlbums, (state) => albumAdapter.removeAll(state)),
   on(loadAlbums, (state) => state),
   on(loadAlbumsSuccess, (state, action) =>
-    albumAdapter.addMany(action.data, state)
+    albumAdapter.setAll(action.data, state)
   ),
   on(loadAlbumsFailure, (state) => state),
   on(addAlbum, (state, action) => albumAdapter.addOne(action.album, state)),

--- a/src/app/database/artists/artist.model.ts
+++ b/src/app/database/artists/artist.model.ts
@@ -1,5 +1,6 @@
 import { hash } from '@app/core/utils';
 import { Opaque } from 'type-fest';
+import { EntryId } from '@app/database/entries/entry.model';
 
 export type ArtistId = Opaque<string, Artist>;
 
@@ -7,6 +8,7 @@ export const getArtistId = (name: string): ArtistId => hash(name) as ArtistId;
 
 export type Artist = {
   id: ArtistId;
+  entries: EntryId[];
   name: string;
   updatedOn: number;
   likedOn?: number;

--- a/src/app/database/artists/artist.reducer.ts
+++ b/src/app/database/artists/artist.reducer.ts
@@ -38,7 +38,7 @@ export const artistReducer = createReducer(
   on(removeAllArtists, (state) => artistAdapter.removeAll(state)),
   on(loadArtists, (state) => state),
   on(loadArtistsSuccess, (state, action) =>
-    artistAdapter.addMany(action.data, state)
+    artistAdapter.setAll(action.data, state)
   ),
   on(loadArtistsFailure, (state) => state),
   on(addArtist, (state, action) => artistAdapter.addOne(action.artist, state)),

--- a/src/app/database/database.module.ts
+++ b/src/app/database/database.module.ts
@@ -44,24 +44,16 @@ const musicSourceDatabase: ReactiveIDBDatabaseOptions = {
   name: 'musicsource',
   schema: [
     {
-      version: 2,
-      stores: [
-        {
-          name: 'settings',
-        },
-      ],
-    },
-    {
       version: 1,
       stores: [
         {
           name: 'entries',
-          options: { keyPath: 'path' },
+          options: { keyPath: 'id' },
           indexes: ['parent'],
         },
         {
           name: 'songs',
-          options: { keyPath: 'entryPath' },
+          options: { keyPath: 'id' },
           indexes: [
             // { name: 'artists', options: { multiEntry: true } },
             // { name: 'genre', options: { multiEntry: true } },
@@ -69,6 +61,11 @@ const musicSourceDatabase: ReactiveIDBDatabaseOptions = {
             'title',
             'likedOn',
             'updatedOn',
+            {
+              name: 'entries',
+              keyPath: 'entries',
+              options: { multiEntry: true },
+            },
           ],
         },
         {
@@ -90,6 +87,11 @@ const musicSourceDatabase: ReactiveIDBDatabaseOptions = {
               keyPath: 'songs',
               options: { multiEntry: true },
             },
+            {
+              name: 'entries',
+              keyPath: 'entries',
+              options: { multiEntry: true },
+            },
           ],
         },
         {
@@ -104,17 +106,34 @@ const musicSourceDatabase: ReactiveIDBDatabaseOptions = {
             // 'albumArtist',
             'likedOn',
             'updatedOn',
+            {
+              name: 'entries',
+              keyPath: 'entries',
+              options: { multiEntry: true },
+            },
           ],
         },
         {
           name: 'artists',
           options: { keyPath: 'id' },
-          indexes: ['name', 'likedOn', 'updatedOn'],
+          indexes: [
+            'name',
+            'likedOn',
+            'updatedOn',
+            {
+              name: 'entries',
+              keyPath: 'entries',
+              options: { multiEntry: true },
+            },
+          ],
         },
         {
           name: 'playlists',
           options: { keyPath: 'id' },
           indexes: ['title', 'createdOn'],
+        },
+        {
+          name: 'settings',
         },
       ],
     },

--- a/src/app/database/database.service.ts
+++ b/src/app/database/database.service.ts
@@ -202,6 +202,22 @@ export class DatabaseService {
     );
   }
 
+  getKey$<T>(
+    store: string,
+    key: IDBValidKey,
+    index?: string
+  ): Observable<IDBValidKey | undefined> {
+    return this.db$.pipe(
+      concatMap((db) => db.transaction$(store)),
+      map((transaction) =>
+        index
+          ? transaction.objectStore<T>(store).index(index)
+          : transaction.objectStore<T>(store)
+      ),
+      concatMap((s) => s.getKey$(key))
+    );
+  }
+
   getAll$<T>(
     store: string,
     index?: string,
@@ -216,6 +232,23 @@ export class DatabaseService {
           : transaction.objectStore<T>(store)
       ),
       concatMap((s) => s.getAll$(query, count))
+    );
+  }
+
+  getAllKeys$<T>(
+    store: string,
+    index?: string,
+    query?: IDBValidKey | IDBKeyRange | null,
+    count?: number
+  ): Observable<IDBValidKey[]> {
+    return this.db$.pipe(
+      concatMap((db) => db.transaction$(store)),
+      map((transaction) =>
+        index
+          ? transaction.objectStore<T>(store).index(index)
+          : transaction.objectStore<T>(store)
+      ),
+      concatMap((s) => s.getAllKeys$(query, count))
     );
   }
 

--- a/src/app/database/entries/entry.facade.ts
+++ b/src/app/database/entries/entry.facade.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { Observable } from 'rxjs';
 import { EntryIndex } from '@app/database/entries/entry.reducer';
-import { Entry } from '@app/database/entries/entry.model';
+import { Entry, EntryId } from '@app/database/entries/entry.model';
 import {
   selectEntryAll,
   selectEntryByKey,
@@ -11,7 +11,7 @@ import {
 } from '@app/database/entries/entry.selectors';
 import { addEntry } from '@app/database/entries/entry.actions';
 import { DatabaseService } from '@app/database/database.service';
-import { tap } from 'rxjs/operators';
+import { map, tap } from 'rxjs/operators';
 
 @Injectable()
 export class EntryFacade {
@@ -23,7 +23,7 @@ export class EntryFacade {
       .pipe(tap(() => this.store.dispatch(addEntry({ entry }))));
   }
 
-  getByKey(key: string): Observable<Entry | undefined> {
+  getByKey(key: EntryId): Observable<Entry | undefined> {
     return this.store.select(selectEntryByKey(key));
   }
 
@@ -35,5 +35,9 @@ export class EntryFacade {
 
   getTotal(): Observable<number> {
     return this.store.select(selectEntryTotal);
+  }
+
+  exists(id: EntryId): Observable<boolean> {
+    return this.database.getKey$('entries', id).pipe(map((key) => !!key));
   }
 }

--- a/src/app/database/entries/entry.model.ts
+++ b/src/app/database/entries/entry.model.ts
@@ -1,7 +1,14 @@
 import { from, Observable, of, throwError } from 'rxjs';
 import { concatMap } from 'rxjs/operators';
+import { Opaque } from 'type-fest';
+import { hash } from '@app/core/utils';
+
+export type EntryId = Opaque<string, Entry>;
+
+export const getEntryId = (path: string): EntryId => hash(path) as EntryId;
 
 export type FileEntry = {
+  id: EntryId;
   kind: 'file';
   name: string;
   path: string;
@@ -10,6 +17,7 @@ export type FileEntry = {
 };
 
 export type DirectoryEntry = {
+  id: EntryId;
   kind: 'directory';
   name: string;
   path: string;
@@ -19,17 +27,17 @@ export type DirectoryEntry = {
 
 export type Entry = FileEntry | DirectoryEntry;
 
-export const isFile = (entry: Entry): entry is FileEntry =>
-  entry.kind === 'file';
-
-export const isDirectory = (entry: Entry): entry is DirectoryEntry =>
-  entry.kind === 'directory';
-
-export const isDirectChild = (parent: DirectoryEntry, child: Entry): boolean =>
-  parent.path === child.parent;
-
-export const isChild = (parent: DirectoryEntry, child: Entry): boolean =>
-  !!child.path?.startsWith(parent.path + '/');
+// export const isFile = (entry: Entry): entry is FileEntry =>
+//   entry.kind === 'file';
+//
+// export const isDirectory = (entry: Entry): entry is DirectoryEntry =>
+//   entry.kind === 'directory';
+//
+// export const isDirectChild = (parent: DirectoryEntry, child: Entry): boolean =>
+//   parent.path === child.parent;
+//
+// export const isChild = (parent: DirectoryEntry, child: Entry): boolean =>
+//   !!child.path?.startsWith(parent.path + '/');
 
 export const requestPermissionPromise = async (
   fileHandle: FileSystemHandle,
@@ -65,10 +73,15 @@ export const requestPermission = (handle: FileSystemHandle): Observable<void> =>
 export const entryFromHandle = (
   handle: FileSystemHandle,
   parent?: string
-): Entry => ({
-  kind: handle.kind,
-  name: handle.name,
-  parent: parent as any,
-  path: parent ? `${parent}/${handle.name}` : handle.name,
-  handle: handle as any,
-});
+): Entry => {
+  const path = parent ? `${parent}/${handle.name}` : handle.name;
+
+  return {
+    id: getEntryId(path),
+    kind: handle.kind,
+    name: handle.name,
+    parent: parent as any,
+    path,
+    handle: handle as any,
+  };
+};

--- a/src/app/database/entries/entry.reducer.ts
+++ b/src/app/database/entries/entry.reducer.ts
@@ -18,7 +18,7 @@ export type EntryIndex = typeof indexes[number];
 export type EntryState = IDBEntityState<Entry, EntryIndex>;
 
 export const entryAdapter = createIDBEntityAdapter<Entry, EntryIndex>({
-  keySelector: (model) => model.path,
+  keySelector: (model) => model.id,
   indexes,
 });
 
@@ -30,7 +30,7 @@ export const entryReducer = createReducer(
   on(removeAllEntries, (state) => entryAdapter.removeAll(state)),
   on(loadEntries, (state) => state),
   on(loadEntriesSuccess, (state, action) =>
-    entryAdapter.addMany(action.data, state)
+    entryAdapter.setAll(action.data, state)
   ),
   on(loadEntriesFailure, (state) => state),
   on(addEntry, (state, { entry }) => entryAdapter.addOne(entry, state))

--- a/src/app/database/pictures/picture.facade.ts
+++ b/src/app/database/pictures/picture.facade.ts
@@ -52,7 +52,7 @@ export class PictureFacade {
                     uniq((e) => e.height)
                   ),
                   entries: [...stored.entries, ...picture.entries].filter(
-                    uniq((e) => e.path)
+                    uniq()
                   ),
                   songs: [...stored.songs, ...picture.songs].filter(uniq()),
                   artists: [...stored.artists, ...picture.artists].filter(
@@ -97,13 +97,13 @@ export class PictureFacade {
 
   getSongCover(song: Song, size: PictureSize): Observable<string | undefined> {
     return this.waitForPicturesLoaded().pipe(
-      switchMap(() => this.store.select(selectPictureBySong(song.entryPath))),
+      switchMap(() => this.store.select(selectPictureBySong(song.id))),
       first(),
       concatMap((picture) =>
         picture
           ? of(picture)
           : this.database
-              .get$<Picture>('pictures', song.entryPath, 'songs')
+              .get$<Picture>('pictures', song.id, 'songs')
               .pipe(
                 tap(
                   (p) => p && this.store.dispatch(upsertPicture({ picture: p }))

--- a/src/app/database/pictures/picture.model.ts
+++ b/src/app/database/pictures/picture.model.ts
@@ -3,7 +3,7 @@ import { hash } from '@app/core/utils';
 import { SongId } from '@app/database/songs/song.model';
 import { AlbumId } from '@app/database/albums/album.model';
 import { ArtistId } from '@app/database/artists/artist.model';
-import { FileEntry } from '@app/database/entries/entry.model';
+import { EntryId } from '@app/database/entries/entry.model';
 
 export type PictureId = Opaque<string, Picture>;
 
@@ -16,7 +16,7 @@ export type Picture = {
   data: Buffer;
   format: string;
   sources: { src: string; height: number; width?: number }[];
-  entries: FileEntry[];
+  entries: EntryId[];
   songs: SongId[];
   albums: AlbumId[];
   artists: ArtistId[];

--- a/src/app/database/pictures/picture.reducer.ts
+++ b/src/app/database/pictures/picture.reducer.ts
@@ -41,7 +41,7 @@ export const pictureReducer = createReducer<PictureState>(
   on(removeAllPictures, (state) => pictureAdapter.removeAll(state)),
   on(loadPictures, (state) => state),
   on(loadPicturesSuccess, (state, { data }) =>
-    pictureAdapter.addMany(data, { ...state, loaded: true })
+    pictureAdapter.setAll(data, { ...state, loaded: true })
   ),
   on(loadPicturesFailure, (state, { error }) => ({ ...state, error })),
   on(addPicture, (state, action) =>

--- a/src/app/database/playlists/playlist.reducer.ts
+++ b/src/app/database/playlists/playlist.reducer.ts
@@ -32,7 +32,7 @@ export const playlistReducer = createReducer(
   on(removeAllPlaylists, (state) => playlistAdapter.removeAll(state)),
   on(loadPlaylists, (state) => state),
   on(loadPlaylistsSuccess, (state, action) =>
-    playlistAdapter.addMany(action.data, state)
+    playlistAdapter.setAll(action.data, state)
   ),
   on(loadPlaylistsFailure, (state) => state),
   on(updatePlaylist, (state, action) =>

--- a/src/app/database/settings/settings.effects.ts
+++ b/src/app/database/settings/settings.effects.ts
@@ -1,16 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import {
-  clearDatabase,
-  synchronizeLibrary,
-} from '@app/database/settings/settings.actions';
-import { filter, map, mergeMap, switchMap, tap } from 'rxjs/operators';
-import { openDirectory } from '@app/scanner/store/scanner.actions';
-import { SettingsFacade } from '@app/database/settings/settings.facade';
-import {
-  DirectoryEntry,
-  requestPermission,
-} from '@app/database/entries/entry.model';
+import { clearDatabase } from '@app/database/settings/settings.actions';
+import { filter, mergeMap, switchMap, tap } from 'rxjs/operators';
 import { concatTap } from '@app/core/utils';
 import { removeAllAlbums } from '@app/database/albums/album.actions';
 import { removeAllArtists } from '@app/database/artists/artist.actions';
@@ -28,16 +19,6 @@ import { from } from 'rxjs';
 @Injectable()
 // noinspection JSUnusedGlobalSymbols
 export class SettingsEffects {
-  synchronize$ = createEffect(() =>
-    this.actions$.pipe(
-      ofType(synchronizeLibrary),
-      switchMap(() => this.settings.getRootDirectory()),
-      filter((directory): directory is DirectoryEntry => !!directory),
-      concatTap((dir) => requestPermission(dir.handle)),
-      map((directory) => openDirectory({ directory }))
-    )
-  );
-
   clearDB$ = createEffect(() =>
     this.actions$.pipe(
       ofType(clearDatabase),
@@ -74,7 +55,6 @@ export class SettingsEffects {
     private router: Router,
     private dialog: MatDialog,
     private actions$: Actions,
-    private settings: SettingsFacade,
     private database: DatabaseService
   ) {}
 }

--- a/src/app/database/settings/settings.facade.ts
+++ b/src/app/database/settings/settings.facade.ts
@@ -3,10 +3,7 @@ import { DatabaseService } from '@app/database/database.service';
 import { Observable } from 'rxjs';
 import { Settings } from '@app/database/settings/settings.model';
 import { Store } from '@ngrx/store';
-import {
-  clearDatabase,
-  synchronizeLibrary,
-} from '@app/database/settings/settings.actions';
+import { clearDatabase } from '@app/database/settings/settings.actions';
 
 @Injectable()
 export class SettingsFacade {
@@ -14,10 +11,6 @@ export class SettingsFacade {
 
   clearDatabase(): void {
     this.store.dispatch(clearDatabase());
-  }
-
-  synchronizeLibrary(): void {
-    this.store.dispatch(synchronizeLibrary());
   }
 
   getRootDirectory(): Observable<Settings['rootDirectory'] | undefined> {

--- a/src/app/database/songs/song.actions.ts
+++ b/src/app/database/songs/song.actions.ts
@@ -22,3 +22,8 @@ export const updateSong = createAction(
 );
 
 export const addSong = createAction('[Song] Add Song', props<{ song: Song }>());
+
+export const upsertSong = createAction(
+  '[Song] Upsert Song',
+  props<{ song: Song }>()
+);

--- a/src/app/database/songs/song.model.ts
+++ b/src/app/database/songs/song.model.ts
@@ -3,14 +3,16 @@ import { AlbumId } from '@app/database/albums/album.model';
 import { PictureId } from '@app/database/pictures/picture.model';
 import { ArtistId } from '@app/database/artists/artist.model';
 import { Opaque } from 'type-fest';
+import { EntryId } from '@app/database/entries/entry.model';
+import { hash } from '@app/core/utils';
 
 export type SongId = Opaque<string, Song>;
 
-export const getSongId = (path: string): SongId => path as SongId;
+export const getSongId = (path: string): SongId => hash(path) as SongId;
 
 export type Song = {
-  entryPath: SongId;
-  folder: string;
+  id: SongId;
+  entries: EntryId[];
   title?: string;
   album: { title: string; id: AlbumId };
   artists: { name: string; id: ArtistId }[];

--- a/src/app/database/songs/song.reducer.ts
+++ b/src/app/database/songs/song.reducer.ts
@@ -8,6 +8,7 @@ import {
   loadSongsSuccess,
   removeAllSongs,
   updateSong,
+  upsertSong,
 } from './song.actions';
 
 export const songFeatureKey = 'songs';
@@ -32,7 +33,7 @@ const indexNames = indexes.map((i) => i.name);
 export type SongIndex = typeof indexNames[number];
 
 export const songAdapter = createIDBEntityAdapter<Song, SongIndex>({
-  keySelector: (model) => model.entryPath,
+  keySelector: (model) => model.id,
   indexes,
 });
 
@@ -46,11 +47,12 @@ export const songReducer = createReducer(
   on(removeAllSongs, (state) => songAdapter.removeAll(state)),
   on(loadSongs, (state) => state),
   on(loadSongsSuccess, (state, action) =>
-    songAdapter.addMany(action.data, state)
+    songAdapter.setAll(action.data, state)
   ),
   on(loadSongsFailure, (state) => state),
   on(updateSong, (state, action) =>
     songAdapter.updateOne(action.update, state)
   ),
-  on(addSong, (state, action) => songAdapter.addOne(action.song, state))
+  on(addSong, (state, action) => songAdapter.addOne(action.song, state)),
+  on(upsertSong, (state, action) => songAdapter.upsertOne(action.song, state))
 );

--- a/src/app/helper/helper.effects.ts
+++ b/src/app/helper/helper.effects.ts
@@ -81,9 +81,7 @@ export class HelperEffects implements OnRunEffects {
         this.songs.getByAlbumKey(id).pipe(
           filter((songs): songs is Song[] => !!songs),
           first(),
-          map((songs) =>
-            playSongs({ songs: songs.map((s) => s.entryPath), shuffle })
-          )
+          map((songs) => playSongs({ songs: songs.map((s) => s.id), shuffle }))
         )
       )
     )
@@ -112,7 +110,7 @@ export class HelperEffects implements OnRunEffects {
           map((songs) =>
             shuffleArray(songs)
               .slice(0, 50)
-              .map((s) => s.entryPath)
+              .map((s) => s.id)
           ),
           map((songs) => playSongs({ songs, shuffle: false }))
         )
@@ -129,7 +127,7 @@ export class HelperEffects implements OnRunEffects {
           first(),
           map((songs) =>
             addSongsToQueue({
-              songs: songs.map((s) => s.entryPath),
+              songs: songs.map((s) => s.id),
               next,
               message: next ? 'Album will play next' : 'Album added to queue',
             })
@@ -203,9 +201,7 @@ export class HelperEffects implements OnRunEffects {
         this.songs.getByAlbumKey(id).pipe(
           filter((songs): songs is Song[] => !!songs),
           first(),
-          map((songs) =>
-            addSongsToPlaylist({ songs: songs.map((s) => s.entryPath) })
-          )
+          map((songs) => addSongsToPlaylist({ songs: songs.map((s) => s.id) }))
         )
       )
     )
@@ -264,7 +260,7 @@ export class HelperEffects implements OnRunEffects {
         ]).pipe(
           first(),
           map(([playlist, index]) => {
-            // const indexToDelete = playlist.indexOf(song.entryPath);
+            // const indexToDelete = playlist.indexOf(song.id);
             const newPlaylist = [...playlist];
             newPlaylist.splice(indexToDelete ?? index, 1);
             return setQueue({

--- a/src/app/library/library-songs.component.ts
+++ b/src/app/library/library-songs.component.ts
@@ -36,9 +36,9 @@ import { SongIndex } from '@app/database/songs/song.reducer';
         <ng-container *ngFor="let song of songs$ | async; trackBy: trackBy">
           <app-song-list-item
             [song]="song"
-            [queue]="[song.entryPath]"
+            [queue]="[song.id]"
             cdkMonitorSubtreeFocus
-            [class.selected]="(currentSongPath$ | async) === song.entryPath"
+            [class.selected]="(currentSongPath$ | async) === song.id"
           ></app-song-list-item>
         </ng-container>
         <div [style.height.px]="bottom$ | async" class="filler"></div>
@@ -56,7 +56,7 @@ import { SongIndex } from '@app/database/songs/song.reducer';
         <!--              [playlist]="[song]"-->
         <!--              *ngIf="!sort.likes || !!song.likedOn"-->
         <!--              cdkMonitorSubtreeFocus-->
-        <!--              [class.selected]="(currentSongPath$ | async) === song.entryPath"-->
+        <!--              [class.selected]="(currentSongPath$ | async) === song.id"-->
         <!--            ></app-song-list-item>-->
         <!--          </ng-container>-->
         <!--          <p class="empty" *ngIf="i === 0">Nothing to display</p>-->
@@ -128,7 +128,7 @@ export class LibrarySongsComponent implements OnInit {
   currentSongPath$ = this.player.getCurrentSong$().pipe(
     filter((id): id is SongId => !!id),
     switchMap((path) => this.songs.getByKey(path)),
-    map((song) => song?.entryPath)
+    map((song) => song?.id)
   );
 
   constructor(
@@ -276,6 +276,6 @@ export class LibrarySongsComponent implements OnInit {
   // }
 
   trackBy(index: number, song: Song): string {
-    return song.entryPath;
+    return song.id;
   }
 }

--- a/src/app/library/store/library.facade.ts
+++ b/src/app/library/store/library.facade.ts
@@ -153,7 +153,7 @@
 //   // }
 //   // toggleSongFavorite(song: Song): Observable<Song> {
 //   //   const update = { likedOn: !!song.likedOn ? undefined : new Date() };
-//   //   return this.storage.update$<Song>('songs', update, song.entryPath).pipe(
+//   //   return this.storage.update$<Song>('songs', update, song.id).pipe(
 //   //     map(() => ({
 //   //       ...song,
 //   //       ...update,
@@ -217,7 +217,7 @@
 //   // }
 //   // createTempPlaylist(songs: Song[]): Observable<IDBValidKey> {
 //   //   const playlist: TempPlaylist = {
-//   //     songs: songs.map((s) => s.entryPath),
+//   //     songs: songs.map((s) => s.id),
 //   //     createdOn: new Date(),
 //   //     hash: hash(new Date().toISOString()),
 //   //   };
@@ -239,7 +239,7 @@
 //   //       this.storage.update$(
 //   //         'playlists',
 //   //         {
-//   //           songs: [...playlist.songs, ...songs.map((song) => song.entryPath)],
+//   //           songs: [...playlist.songs, ...songs.map((song) => song.id)],
 //   //           pictureKey:
 //   //             playlist.pictureKey ||
 //   //             songs.find((song) => song.pictureKey)?.pictureKey,

--- a/src/app/library/store/library.state.ts
+++ b/src/app/library/store/library.state.ts
@@ -25,7 +25,7 @@
 // });
 //
 // export const songAdapter: EntityAdapter<Song> = createEntityAdapter<Song>({
-//   selectId: (model) => model.entryPath,
+//   selectId: (model) => model.id,
 // });
 //
 // export const pictureAdapter: EntityAdapter<Picture> = createEntityAdapter<

--- a/src/app/player/play.component.ts
+++ b/src/app/player/play.component.ts
@@ -195,12 +195,9 @@ export class PlayComponent implements OnInit, AfterViewInit {
   }
 
   drop(playlist: Song[], currentSong: Song, event: CdkDragDrop<Song[]>): void {
-    const newPlaylist = [...playlist.map((s) => s.entryPath)];
+    const newPlaylist = [...playlist.map((s) => s.id)];
     moveItemInArray(newPlaylist, event.previousIndex, event.currentIndex);
-    this.player.setQueue(
-      newPlaylist,
-      newPlaylist.indexOf(currentSong.entryPath)
-    );
+    this.player.setQueue(newPlaylist, newPlaylist.indexOf(currentSong.id));
   }
 
   analyzerToggle() {

--- a/src/app/player/player.component.ts
+++ b/src/app/player/player.component.ts
@@ -490,12 +490,12 @@ export class PlayerComponent implements OnInit, OnDestroy {
         {
           text: 'Play next',
           icon: this.icons.playlistPlay,
-          click: () => this.helper.addSongToQueue(song.entryPath, true),
+          click: () => this.helper.addSongToQueue(song.id, true),
         },
         {
           text: 'Add to queue',
           icon: this.icons.playlistMusic,
-          click: () => this.helper.addSongToQueue(song.entryPath, false),
+          click: () => this.helper.addSongToQueue(song.id, false),
         },
         {
           text: !!song.likedOn ? 'Remove from your likes' : 'Add to your likes',
@@ -505,7 +505,7 @@ export class PlayerComponent implements OnInit, OnDestroy {
         {
           text: 'Add to playlist',
           icon: this.icons.playlistPlus,
-          click: () => this.helper.addSongsToPlaylist([song.entryPath]),
+          click: () => this.helper.addSongsToPlaylist([song.id]),
         },
         {
           text: 'Remove from queue',

--- a/src/app/player/queue-item.component.ts
+++ b/src/app/player/queue-item.component.ts
@@ -194,11 +194,11 @@ export class QueueItemComponent implements OnInit {
   }
 
   playNext(song: Song): void {
-    this.helper.addSongToQueue(song.entryPath, true);
+    this.helper.addSongToQueue(song.id, true);
   }
 
   addToQueue(song: Song): void {
-    this.helper.addSongToQueue(song.entryPath, false);
+    this.helper.addSongToQueue(song.id, false);
   }
 
   toggleLiked(song: Song): void {
@@ -206,7 +206,7 @@ export class QueueItemComponent implements OnInit {
   }
 
   addToPlaylist(song: Song): void {
-    this.helper.addSongsToPlaylist([song.entryPath]);
+    this.helper.addSongsToPlaylist([song.id]);
   }
 
   removeFromQueue(index: number): void {

--- a/src/app/player/queue-list.component.ts
+++ b/src/app/player/queue-list.component.ts
@@ -12,9 +12,7 @@ import { Song, SongId } from '@app/database/songs/song.model';
       [song]="song"
       [index]="i"
       [queue]="getIds(songs)"
-      [class.selected]="
-        song.entryPath === currentSong?.entryPath && currentIndex === i
-      "
+      [class.selected]="song.id === currentSong?.id && currentIndex === i"
     ></app-queue-item>
   `,
   styles: [
@@ -66,10 +64,10 @@ export class QueueListComponent {
   @Input() currentIndex!: number | null;
 
   trackBy(index: number, song: Song): string {
-    return song.entryPath;
+    return song.id;
   }
 
   getIds(songs: Song[]): SongId[] {
-    return songs.map((s) => s.entryPath);
+    return songs.map((s) => s.id);
   }
 }

--- a/src/app/playlist/page-playlist-likes.component.ts
+++ b/src/app/playlist/page-playlist-likes.component.ts
@@ -93,7 +93,7 @@ export class PagePlaylistLikesComponent implements OnInit {
           icon: Icons.playlistPlay,
           click: () =>
             this.helper.addSongsToQueue(
-              songs.map((s) => s.entryPath),
+              songs.map((s) => s.id),
               true,
               'Your likes will play next'
             ),
@@ -103,7 +103,7 @@ export class PagePlaylistLikesComponent implements OnInit {
           icon: Icons.playlistPlus,
           click: () =>
             this.helper.addSongsToQueue(
-              songs.map((s) => s.entryPath),
+              songs.map((s) => s.id),
               false,
               'Your likes have been added to queue'
             ),
@@ -119,7 +119,7 @@ export class PagePlaylistLikesComponent implements OnInit {
 
   shuffle(songs: Song[]): void {
     this.helper.playSongs(
-      songs.map((s) => s.entryPath),
+      songs.map((s) => s.id),
       true
     );
   }

--- a/src/app/scanner/extractor.worker.ts
+++ b/src/app/scanner/extractor.worker.ts
@@ -41,16 +41,18 @@ addEventListener('message', async ({ data }) => {
     const albumTitle = tags.album || 'Unknown album';
     const title = tags.title || entry.name;
 
-    const updatedOn = Date.now();
+    const updatedOn = file.lastModified;
 
     const artists: Artist[] = artistsTags.map((name) => ({
       id: getArtistId(name),
+      entries: [entry.id],
       name,
       updatedOn,
     }));
 
     const albumArtist: Artist = {
       id: getArtistId(albumArtistName),
+      entries: [entry.id],
       name: albumArtistName,
       updatedOn,
     };
@@ -61,6 +63,7 @@ addEventListener('message', async ({ data }) => {
 
     const album: Album = {
       id: getAlbumId(albumArtist.name, albumTitle),
+      entries: [entry.id],
       title: albumTitle,
       albumArtist: {
         name: albumArtist.name,
@@ -73,8 +76,8 @@ addEventListener('message', async ({ data }) => {
     };
 
     const song: Song = {
-      entryPath: getSongId(entry.path),
-      folder: entry.parent,
+      id: getSongId(`${title}-${albumTitle}-${albumArtistName}`),
+      entries: [entry.id],
       title,
       artists: artists.map((a) => ({ name: a.name, id: a.id })),
       album: { title: album.title, id: album.id },
@@ -91,8 +94,8 @@ addEventListener('message', async ({ data }) => {
       data: picture.data,
       format: picture.format,
       sources: [],
-      entries: [entry],
-      songs: [song.entryPath],
+      entries: [entry.id],
+      songs: [song.id],
       albums: [album.id],
       artists: [albumArtist.id],
     }));

--- a/src/app/scanner/file.service.ts
+++ b/src/app/scanner/file.service.ts
@@ -21,12 +21,13 @@ export class FileService {
 
   iterate(dir: DirectoryEntry): Observable<Entry> {
     const generator: (
-      directory: FileSystemDirectoryHandle
+      directory: DirectoryEntry
     ) => AsyncGenerator<Entry, void, void> = async function* (
-      directory: FileSystemDirectoryHandle
+      directory: DirectoryEntry
     ) {
-      for await (const entry of directory.values()) {
-        yield entryFromHandle(entry, directory.name);
+      for await (const handle of directory.handle.values()) {
+        const entry = entryFromHandle(handle, directory.path);
+        yield entry;
         if (entry.kind === 'directory') {
           yield* generator(entry);
         }
@@ -34,6 +35,6 @@ export class FileService {
     };
 
     // return scheduled(generator(dir.handle), animationFrameScheduler);
-    return from(generator(dir.handle));
+    return from(generator(dir));
   }
 }

--- a/src/app/scanner/store/scanner.actions.ts
+++ b/src/app/scanner/store/scanner.actions.ts
@@ -1,6 +1,8 @@
 import { createAction, props } from '@ngrx/store';
 import { DirectoryEntry } from '@app/database/entries/entry.model';
 
+export const quickSync = createAction('scanner/sync');
+
 export const openDirectory = createAction(
   'scanner/open',
   props<{ directory?: DirectoryEntry }>()

--- a/src/app/scanner/store/scanner.facade.ts
+++ b/src/app/scanner/store/scanner.facade.ts
@@ -6,6 +6,7 @@ import {
   selectState,
 } from '@app/scanner/store/scanner.selectors';
 import {
+  quickSync,
   scanEnd,
   scanStart,
   setLabel,
@@ -29,5 +30,9 @@ export class ScannerFacade {
 
   setLabel(label: string): void {
     this.store.dispatch(setLabel({ label }));
+  }
+
+  quickSync() {
+    this.store.dispatch(quickSync());
   }
 }


### PR DESCRIPTION
feat: quick sync (account for added/deleted files)
feat: support multiple files per song
refactor: add entries to albums, songs, and artists
fix: use adapters setAll on load
refactor: use opaque EntryId for files
fix: flashing covers on likes when syncing
refactor: scanner effect
fix: use lastModified date as updatedOn value
fix: prepend correct path in file entries

closes #53 
